### PR TITLE
Removed several differences and moved them to patches or scripts

### DIFF
--- a/erizo_controller/installErizo_controller.sh
+++ b/erizo_controller/installErizo_controller.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 
-set -e
-
 echo [erizo_controller] Installing node_modules for erizo_controller
 
-# this is in ging master.  But I added these to package.json to version lock.
-#npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt
-npm install
+npm install --loglevel error amqp socket.io@0.9.16 log4js node-getopt
 
 echo [erizo_controller] Done, node_modules installed
 

--- a/nuve/installNuve.sh
+++ b/nuve/installNuve.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -16,10 +14,7 @@ cd nuveAPI
 
 echo [nuve] Installing node_modules for nuve
 
-# this is in ging master.  But I added these to package.json to version lock.
-#npm install --loglevel error amqp express@3 mongojs aws-lib log4js node-getopt
-npm install --loglevel error body-parser
-
+npm install --loglevel error amqp express mongojs@2.3.0 aws-lib log4js node-getopt body-parser
 echo [nuve] Done, node_modules installed
 
 cd ../nuveClient/tools

--- a/nuve/nuveAPI/nuve.js
+++ b/nuve/nuveAPI/nuve.js
@@ -1,6 +1,5 @@
 /*global require, __dirname*/
 'use strict';
-var newrelic = require('newrelic'); // jshint ignore:line
 var express = require('express');
 var bodyParser = require('body-parser');
 var rpc = require('./rpc/rpc');

--- a/nuve/nuveAPI/nuve.js
+++ b/nuve/nuveAPI/nuve.js
@@ -1,6 +1,6 @@
 /*global require, __dirname*/
-var newrelic = require('newrelic');
 'use strict';
+var newrelic = require('newrelic'); // jshint ignore:line
 var express = require('express');
 var bodyParser = require('body-parser');
 var rpc = require('./rpc/rpc');

--- a/scripts/installBasicExample.sh
+++ b/scripts/installBasicExample.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 SCRIPT=`pwd`/$0
 FILENAME=`basename $SCRIPT`
 PATHNAME=`dirname $SCRIPT`
@@ -13,10 +11,7 @@ EXTRAS=$ROOT/extras
 
 cd $EXTRAS/basic_example
 
-npm install --loglevel error express@3.5.1 body-parser morgan errorhandler
-
-cp -r $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
-cp -r $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
 cp -r ${ROOT}/erizo_controller/erizoClient/dist/assets public/
 
+npm install --loglevel error express body-parser morgan errorhandler
 cd $CURRENT_DIR

--- a/scripts/installLicodeMinerva.sh
+++ b/scripts/installLicodeMinerva.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT=`pwd`/$0
+FILENAME=`basename $SCRIPT`
+PATHNAME=`dirname $SCRIPT`
+ROOT=$PATHNAME/..
+BUILD_DIR=$ROOT/build
+CURRENT_DIR=`pwd`
+DB_DIR="$BUILD_DIR"/db
+EXTRAS=$ROOT/extras
+
+echo [minerva/licode] copying nuve.js and erizo.js to basic_example
+
+cd $EXTRAS/basic_example
+
+cp -r $ROOT/erizo_controller/erizoClient/dist/erizo.js $EXTRAS/basic_example/public/
+cp -r $ROOT/nuve/nuveClient/dist/nuve.js $EXTRAS/basic_example/
+
+cd $CURRENT_DIR
+
+echo [minerva/licode] installing newrelic for nuve
+
+cd $ROOT/nuve
+npm install --loglevel error newrelic
+cd $CURRENT_DIR
+
+echo [minerva/licode] applying nuve patch
+
+cd $ROOT
+patch -p0 < $PATHNAME/minerva_nuve.patch0
+cd $CURRENT_DIR

--- a/scripts/minerva_nuve.patch0
+++ b/scripts/minerva_nuve.patch0
@@ -1,0 +1,9 @@
+--- nuve/nuveAPI/nuve.js	2016-10-20 19:24:52.000000000 +0200
++++ nuve/nuveAPI/nuve.js	2016-10-27 15:10:47.000000000 +0200
+@@ -1,5 +1,6 @@
+ /*global require, __dirname*/
+ 'use strict';
++var newrelic = require('newrelic'); // jshint ignore:line
+ var express = require('express');
+ var bodyParser = require('body-parser');
+ var rpc = require('./rpc/rpc');


### PR DESCRIPTION
The differences in the installation scripts for node components, package.json and nuve were making merges from ging/master harder and error prone.
This PR starts unifying both installation processes by putting dependencies back in installation scripts instead of package.json. We _will_ move dependencies to package.json at some point but we will do this in ging/master.

Also, the differences in nuve.js and in the installation scripts have been moved to a patch and are now applied with `installLicodeMinerva.sh` that now will be part of the deploy process