### PR TITLE
Fix bug in installation of opus library

### DIFF
--- a/scripts/installUbuntuDeps.sh
+++ b/scripts/installUbuntuDeps.sh
@@ -134,7 +134,7 @@ install_opus(){
   [ -d $LIB_DIR ] || mkdir -p $LIB_DIR
   cd $LIB_DIR
   if [ ! -f ./opus-1.1.tar.gz ]; then
-    curl -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+    curl -L -O http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
     tar -zxvf opus-1.1.tar.gz
     cd opus-1.1
     ./configure --prefix=$PREFIX_DIR


### PR DESCRIPTION
@lodoyun, @jcague, the URL for the opus tarball (http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz) started redirecting to another location (https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.1.tar.gz), causing deployment failures. Rather than hard-code the new URL into the script, I put in a `-L` option to make curl follow the redirect. Let me know if you'd rather just hard-code it.

